### PR TITLE
Rename iva column and add activo flag to presupuestos

### DIFF
--- a/app/Filament/Resources/PresupuestoResource.php
+++ b/app/Filament/Resources/PresupuestoResource.php
@@ -35,7 +35,7 @@ class PresupuestoResource extends Resource
                 ->required()
                 ->searchable(),
             Forms\Components\TextInput::make('base_imponible')->numeric()->required(),
-            Forms\Components\TextInput::make('iva')->numeric()->default(21),
+            Forms\Components\TextInput::make('iva_porcentaje')->numeric()->default(21),
             Forms\Components\TextInput::make('total')->numeric()->required(),
             Forms\Components\Select::make('estado')
                 ->options([
@@ -43,6 +43,7 @@ class PresupuestoResource extends Resource
                     'aceptado' => 'Aceptado',
                     'rechazado' => 'Rechazado',
                 ])->default('pendiente'),
+            Forms\Components\Toggle::make('activo')->default(true),
             Forms\Components\Textarea::make('observaciones'),
         ]);
     }
@@ -56,9 +57,10 @@ class PresupuestoResource extends Resource
                 Tables\Columns\TextColumn::make('fecha')->date()->sortable(),
                 Tables\Columns\TextColumn::make('cliente.nombre')->label('Cliente')->sortable()->searchable(),
                 Tables\Columns\TextColumn::make('base_imponible')->money('EUR'),
-                Tables\Columns\TextColumn::make('iva')->suffix('%'),
+                Tables\Columns\TextColumn::make('iva_porcentaje')->suffix('%'),
                 Tables\Columns\TextColumn::make('total')->money('EUR'),
                 Tables\Columns\TextColumn::make('estado')->badge(),
+                Tables\Columns\IconColumn::make('activo')->boolean(),
             ])
             ->filters([])
             ->actions([

--- a/app/Models/Presupuesto.php
+++ b/app/Models/Presupuesto.php
@@ -15,10 +15,11 @@ class Presupuesto extends Model
         'fecha',
         'cliente_id',
         'base_imponible',
-        'iva',
+        'iva_porcentaje',
         'total',
         'estado',
         'observaciones',
+        'activo',
     ];
 
     public function cliente()

--- a/database/migrations/2025_08_08_000000_create_presupuestos_table.php
+++ b/database/migrations/2025_08_08_000000_create_presupuestos_table.php
@@ -14,11 +14,14 @@ return new class extends Migration {
             $table->date('fecha');
             $table->foreignId('cliente_id')->constrained('clientes')->onDelete('cascade');
             $table->decimal('base_imponible', 10, 2);
-            $table->decimal('iva', 5, 2)->default(21);
+            $table->decimal('iva_porcentaje', 5, 2)->default(21.00);
             $table->decimal('total', 10, 2);
             $table->string('estado')->default('pendiente'); // pendiente, aceptado, rechazado
+            $table->unsignedTinyInteger('activo')->default(1);
             $table->text('observaciones')->nullable();
             $table->timestamps();
+            $table->unique(['serie', 'numero']);
+            $table->index(['cliente_id', 'estado', 'fecha', 'activo']);
         });
     }
 

--- a/database/seeders/PresupuestoSeeder.php
+++ b/database/seeders/PresupuestoSeeder.php
@@ -29,10 +29,11 @@ class PresupuestoSeeder extends Seeder
                 'fecha' => now()->subDays(rand(0, 90)),
                 'cliente_id' => $cliente->id,
                 'base_imponible' => $base,
-                'iva' => $iva,
+                'iva_porcentaje' => $iva,
                 'total' => $total,
                 'estado' => collect(['pendiente', 'aceptado', 'rechazado'])->random(),
                 'observaciones' => 'Observaciones del presupuesto ' . $i,
+                'activo' => 1,
             ]);
         }
     }


### PR DESCRIPTION
## Summary
- rename iva field to iva_porcentaje and add activo flag for presupuestos
- update Presupuesto seeder, model and Filament resource for new fields
- add unique and index constraints to presupuestos table

## Testing
- `php artisan test` *(fails: require vendor/autoload.php)*
- `composer install` *(fails: needs GitHub token, 403)*

------
https://chatgpt.com/codex/tasks/task_e_6895a6721bf8832192bcd2788f994ff7