### PR TITLE
Allow repeated items in presupuesto_productos

### DIFF
--- a/database/migrations/2025_08_08_000100_update_presupuesto_productos_table.php
+++ b/database/migrations/2025_08_08_000100_update_presupuesto_productos_table.php
@@ -1,0 +1,36 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration {
+    public function up(): void
+    {
+        Schema::table('presupuesto_productos', function (Blueprint $table) {
+            // remove unique constraint to allow repeated lines
+            $table->dropUnique('presupuesto_productos_presupuesto_id_producto_id_unique');
+        });
+
+        Schema::table('presupuesto_productos', function (Blueprint $table) {
+            // allow producto_id to be nullable
+            $table->foreignId('producto_id')->nullable()->change();
+
+            // add new descriptive and tax columns
+            $table->string('descripcion', 255);
+            $table->decimal('iva_porcentaje', 5, 2)->default(21);
+            $table->decimal('irpf_porcentaje', 5, 2)->nullable();
+            $table->decimal('subtotal', 14, 2)->default(0);
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('presupuesto_productos', function (Blueprint $table) {
+            $table->dropColumn(['descripcion', 'iva_porcentaje', 'irpf_porcentaje', 'subtotal']);
+            $table->unsignedBigInteger('producto_id')->nullable(false)->change();
+            $table->unique(['presupuesto_id', 'producto_id']);
+        });
+    }
+};
+


### PR DESCRIPTION
## Summary
- add migration dropping unique constraint and making `producto_id` nullable
- add descripcion, iva_porcentaje, irpf_porcentaje, subtotal columns for presupuesto line items

## Testing
- `vendor/bin/phpunit` (fails: No such file or directory)
- `phpunit` (fails: command not found)


------
https://chatgpt.com/codex/tasks/task_e_6895a6b0179c832195abf0c4328fbb6f