### PR TITLE
Add presupuesto and actuacion references to facturas

### DIFF
--- a/app/Models/Factura.php
+++ b/app/Models/Factura.php
@@ -10,11 +10,14 @@ class Factura extends Model
     use HasFactory;
 
     protected $fillable = [
-        'usuario_id','cliente_id','fecha','numero','serie','estado','notas',
+        'usuario_id','cliente_id','presupuesto_id','actuacion_id',
+        'fecha','numero','serie','estado','notas',
         'base_imponible','iva_total','irpf_total','total'
     ];
 
     public function cliente() { return $this->belongsTo(Cliente::class); }
+    public function presupuesto() { return $this->belongsTo(Presupuesto::class); }
+    public function actuacion() { return $this->belongsTo(Actuacion::class); }
     public function lineas() { return $this->hasMany(FacturaProducto::class); }
     public function actuaciones() { return $this->belongsToMany(Actuacion::class, 'actuacion_factura'); }
 

--- a/database/migrations/2025_08_07_000250_create_facturas_tables.php
+++ b/database/migrations/2025_08_07_000250_create_facturas_tables.php
@@ -12,6 +12,8 @@ return new class extends Migration
             $table->id();
             $table->foreignId('usuario_id')->constrained('users')->onDelete('cascade')->onUpdate('cascade');
             $table->foreignId('cliente_id')->constrained('clientes')->onDelete('cascade')->onUpdate('cascade');
+            $table->foreignId('presupuesto_id')->nullable()->constrained('presupuestos')->cascadeOnUpdate()->nullOnDelete();
+            $table->foreignId('actuacion_id')->nullable()->constrained('actuaciones')->cascadeOnUpdate()->nullOnDelete();
             $table->string('numero')->unique();
             $table->date('fecha');
             $table->decimal('base_imponible', 12, 2)->default(0);


### PR DESCRIPTION
## Summary
- add nullable `presupuesto_id` and `actuacion_id` columns to `facturas` table
- link invoices to budgets and actions in the `Factura` model

## Testing
- `vendor/bin/phpunit` *(fails: No such file or directory)*
- `composer install --no-interaction` *(fails: curl error 56 while downloading from GitHub, response 403)*

------
https://chatgpt.com/codex/tasks/task_e_6895aa4909848321b9e33c7154fe3be5