### PR TITLE
Allow repeated invoice product lines

### DIFF
--- a/database/migrations/2025_08_08_000250_update_factura_productos_table.php
+++ b/database/migrations/2025_08_08_000250_update_factura_productos_table.php
@@ -1,0 +1,41 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration {
+    public function up(): void
+    {
+        Schema::table('factura_productos', function (Blueprint $table) {
+            // remove unique constraint to allow repeated lines
+            try {
+                $table->dropUnique('factura_productos_factura_id_producto_id_unique');
+            } catch (\Exception $e) {
+                // index might not exist in fresh installations
+            }
+        });
+
+        Schema::table('factura_productos', function (Blueprint $table) {
+            // allow producto_id to be nullable and support fractional quantities
+            $table->foreignId('producto_id')->nullable()->change();
+            $table->decimal('cantidad', 12, 3)->default(1)->change();
+
+            // add new tax and subtotal columns
+            $table->decimal('iva_porcentaje', 5, 2)->default(21);
+            $table->decimal('irpf_porcentaje', 5, 2)->nullable();
+            $table->decimal('subtotal', 14, 2)->default(0);
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('factura_productos', function (Blueprint $table) {
+            $table->dropColumn(['iva_porcentaje', 'irpf_porcentaje', 'subtotal']);
+            $table->unsignedBigInteger('producto_id')->nullable(false)->change();
+            $table->integer('cantidad')->default(1)->change();
+            $table->unique(['factura_id', 'producto_id']);
+        });
+    }
+};
+


### PR DESCRIPTION
## Summary
- allow nullable `producto_id` and fractional quantities in invoice lines
- add IVA/IRPF percentage and subtotal columns
- drop unique constraint to permit repeated product lines

## Testing
- `composer test` *(fails: Failed to open required '/workspace/fappv1/vendor/autoload.php')*
- `composer install` *(fails: GitHub API 403 when downloading packages)*

------
https://chatgpt.com/codex/tasks/task_e_6895b57bf6d8832192e0647f0369d34b