### PR TITLE
Actualiza campos de Presupuesto y recursos asociados

### DIFF
--- a/app/Filament/Resources/PresupuestoResource.php
+++ b/app/Filament/Resources/PresupuestoResource.php
@@ -35,7 +35,7 @@ class PresupuestoResource extends Resource
                 ->required()
                 ->searchable(),
             Forms\Components\TextInput::make('base_imponible')->numeric()->required(),
-            Forms\Components\TextInput::make('iva_porcentaje')->numeric()->default(21),
+            Forms\Components\TextInput::make('iva_total')->numeric()->default(0),
             Forms\Components\TextInput::make('total')->numeric()->required(),
             Forms\Components\Select::make('estado')
                 ->options([
@@ -44,7 +44,7 @@ class PresupuestoResource extends Resource
                     'rechazado' => 'Rechazado',
                 ])->default('pendiente'),
             Forms\Components\Toggle::make('activo')->default(true),
-            Forms\Components\Textarea::make('observaciones'),
+            Forms\Components\Textarea::make('notas'),
         ]);
     }
 
@@ -57,7 +57,7 @@ class PresupuestoResource extends Resource
                 Tables\Columns\TextColumn::make('fecha')->date()->sortable(),
                 Tables\Columns\TextColumn::make('cliente.nombre')->label('Cliente')->sortable()->searchable(),
                 Tables\Columns\TextColumn::make('base_imponible')->money('EUR'),
-                Tables\Columns\TextColumn::make('iva_porcentaje')->suffix('%'),
+                Tables\Columns\TextColumn::make('iva_total')->money('EUR'),
                 Tables\Columns\TextColumn::make('total')->money('EUR'),
                 Tables\Columns\TextColumn::make('estado')->badge(),
                 Tables\Columns\IconColumn::make('activo')->boolean(),

--- a/app/Models/Presupuesto.php
+++ b/app/Models/Presupuesto.php
@@ -10,16 +10,8 @@ class Presupuesto extends Model
     use HasFactory;
 
     protected $fillable = [
-        'serie',
-        'numero',
-        'fecha',
-        'cliente_id',
-        'base_imponible',
-        'iva_porcentaje',
-        'total',
-        'estado',
-        'observaciones',
-        'activo',
+        'usuario_id','cliente_id','fecha','numero','serie','estado','validez_dias','notas','activo',
+        'base_imponible','iva_total','irpf_total','total'
     ];
 
     public function cliente()


### PR DESCRIPTION
## Summary
- Añade `usuario_id`, `iva_total`, `irpf_total`, `notas` y `validez_dias` al modelo Presupuesto
- Ajusta PresupuestoResource para utilizar `iva_total` y `notas` en formularios y tablas

## Testing
- `php artisan test` *(falló: Failed opening required '/workspace/fappv1/vendor/autoload.php')*

------
https://chatgpt.com/codex/tasks/task_e_6895b59649ac8321997c78cea7394a41