### PR TITLE
Normalize Actuacion-Factura relationship

### DIFF
--- a/app/Models/Factura.php
+++ b/app/Models/Factura.php
@@ -10,14 +10,13 @@ class Factura extends Model
     use HasFactory;
 
     protected $fillable = [
-        'usuario_id','cliente_id','presupuesto_id','actuacion_id',
+        'usuario_id','cliente_id','presupuesto_id',
         'fecha','numero','serie','estado','notas',
         'base_imponible','iva_total','irpf_total','total'
     ];
 
     public function cliente() { return $this->belongsTo(Cliente::class); }
     public function presupuesto() { return $this->belongsTo(Presupuesto::class); }
-    public function actuacion() { return $this->belongsTo(Actuacion::class); }
     public function lineas() { return $this->hasMany(FacturaProducto::class); }
     public function actuaciones() { return $this->belongsToMany(Actuacion::class, 'actuacion_factura'); }
 

--- a/database/migrations/2025_08_07_000250_create_facturas_tables.php
+++ b/database/migrations/2025_08_07_000250_create_facturas_tables.php
@@ -13,7 +13,6 @@ return new class extends Migration
             $table->foreignId('usuario_id')->constrained('users')->onDelete('cascade')->onUpdate('cascade');
             $table->foreignId('cliente_id')->constrained('clientes')->onDelete('cascade')->onUpdate('cascade');
             $table->foreignId('presupuesto_id')->nullable()->constrained('presupuestos')->cascadeOnUpdate()->nullOnDelete();
-            $table->foreignId('actuacion_id')->nullable()->constrained('actuaciones')->cascadeOnUpdate()->nullOnDelete();
             $table->unsignedBigInteger('numero')->default(0);
             $table->string('serie', 20)->default('A');
             $table->date('fecha');

--- a/database/migrations/fapp/2025_08_07_000300_create_actuacion_factura_pivot.php
+++ b/database/migrations/fapp/2025_08_07_000300_create_actuacion_factura_pivot.php
@@ -13,7 +13,7 @@ return new class extends Migration {
                 $table->foreignId('actuacion_id')->constrained('actuaciones')->cascadeOnUpdate()->cascadeOnDelete();
                 $table->foreignId('factura_id')->constrained('facturas')->cascadeOnUpdate()->cascadeOnDelete();
                 $table->timestamps();
-                $table->unique(['actuacion_id']);
+                $table->unique(['actuacion_id', 'factura_id']);
                 $table->index(['factura_id']);
             });
         }


### PR DESCRIPTION
## Summary
- Ensure pivot table uses a composite unique key for `actuacion_factura`
- Drop legacy `actuacion_id` from `facturas` table
- Remove obsolete one-to-one relation from `Factura` model

## Testing
- `php artisan test` *(fails: require(/workspace/fappv1/vendor/autoload.php): No such file or directory)*
- `composer install` *(fails: GitHub token required for voku/portable-ascii)*

------
https://chatgpt.com/codex/tasks/task_e_6895b58ad0088321ab554e73c451ef45