### PR TITLE
Update estado enum and add estado select

### DIFF
--- a/app/Filament/Resources/FacturaResource.php
+++ b/app/Filament/Resources/FacturaResource.php
@@ -18,8 +18,14 @@ class FacturaResource extends Resource
 
     public static function form(Form $form): Form
     {
-        // Facturas se crean desde actuaciones, aquí se deja vacío o con los campos necesarios
-        return $form->schema([]);
+        return $form->schema([
+            Forms\Components\Select::make('estado')
+                ->options([
+                    'borrador' => 'Borrador',
+                    'enviado' => 'Enviado',
+                    'pagado' => 'Pagado',
+                ]),
+        ]);
     }
 
     public static function table(Table $table): Table

--- a/database/migrations/2025_08_07_000250_create_facturas_tables.php
+++ b/database/migrations/2025_08_07_000250_create_facturas_tables.php
@@ -16,7 +16,7 @@ return new class extends Migration
             $table->unsignedBigInteger('numero')->default(0);
             $table->string('serie', 20)->default('A');
             $table->date('fecha');
-            $table->enum('estado', ['borrador', 'emitida', 'pagada'])->default('borrador');
+            $table->enum('estado', ['borrador', 'enviado', 'pagado'])->default('borrador');
             $table->text('notas')->nullable();
             $table->decimal('base_imponible', 14, 2)->default(0);
             $table->decimal('iva_total', 14, 2)->default(0);

--- a/database/migrations/2025_08_08_000300_update_facturas_estado_enum.php
+++ b/database/migrations/2025_08_08_000300_update_facturas_estado_enum.php
@@ -1,0 +1,22 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('facturas', function (Blueprint $table) {
+            $table->enum('estado', ['borrador', 'enviado', 'pagado'])->default('borrador')->change();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('facturas', function (Blueprint $table) {
+            $table->enum('estado', ['borrador', 'emitida', 'pagada'])->default('borrador')->change();
+        });
+    }
+};


### PR DESCRIPTION
## Summary
- Add "enviado" estado to facturas table enum
- Include estado select in Filament Factura resource
- Provide migration to update existing facturas

## Testing
- `php artisan migrate` *(fails: Failed opening required '/workspace/fappv1/vendor/autoload.php')*
- `composer install --no-interaction --no-progress` *(fails: Failed to clone https://github.com/symfony/polyfill-php80.git: CONNECT tunnel failed, response 403)*
- `php artisan test` *(fails: Failed opening required '/workspace/fappv1/vendor/autoload.php')*


------
https://chatgpt.com/codex/tasks/task_e_6895bf4c1c74832192191134a94f5700