### PR TITLE
feat: rename IVA field and add activo toggle

### DIFF
--- a/app/Filament/Resources/ProductoResource.php
+++ b/app/Filament/Resources/ProductoResource.php
@@ -31,9 +31,12 @@ class ProductoResource extends Resource
                 ->numeric()
                 ->required(),
 
-            Forms\Components\TextInput::make('iva')
+            Forms\Components\TextInput::make('iva_porcentaje')
                 ->numeric()
                 ->default(21),
+
+            Forms\Components\Toggle::make('activo')
+                ->default(true),
         ]);
     }
 
@@ -52,8 +55,11 @@ class ProductoResource extends Resource
                     ->money('eur')
                     ->sortable(),
 
-                Tables\Columns\TextColumn::make('iva')
+                Tables\Columns\TextColumn::make('iva_porcentaje')
                     ->sortable(),
+
+                Tables\Columns\IconColumn::make('activo')
+                    ->boolean(),
             ])
             ->filters([])
             ->actions([


### PR DESCRIPTION
## Summary
- rename IVA form and table fields to `iva_porcentaje`
- add `activo` toggle to form with default true
- show `activo` status in table via boolean icon column

## Testing
- `composer test` *(fails: require vendor autoload; dependencies not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6895c0bc120c8321a507fd5aba20576a