### PR TITLE
Add factura form fields and clean up product tax columns

### DIFF
--- a/app/Filament/Resources/FacturaResource.php
+++ b/app/Filament/Resources/FacturaResource.php
@@ -4,6 +4,7 @@ namespace App\Filament\Resources;
 
 use App\Filament\Resources\FacturaResource\Pages;
 use App\Models\Factura;
+use App\Models\Cliente;
 use Filament\Forms;
 use Filament\Forms\Form;
 use Filament\Resources\Resource;
@@ -19,12 +20,50 @@ class FacturaResource extends Resource
     public static function form(Form $form): Form
     {
         return $form->schema([
+            Forms\Components\Select::make('cliente_id')
+                ->label('Cliente')
+                ->options(
+                    Cliente::query()
+                        ->when(auth()->check() && !auth()->user()->hasRole('admin'), fn($q) => $q->where('usuario_id', auth()->id()))
+                        ->pluck('nombre', 'id')
+                )
+                ->searchable()
+                ->rules(['required', 'numeric']),
+
+            Forms\Components\TextInput::make('serie')
+                ->maxLength(20)
+                ->required(),
+
+            Forms\Components\TextInput::make('numero')
+                ->required()
+                ->numeric(),
+
+            Forms\Components\DatePicker::make('fecha')
+                ->required(),
+
             Forms\Components\Select::make('estado')
                 ->options([
                     'borrador' => 'Borrador',
                     'enviado' => 'Enviado',
                     'pagado' => 'Pagado',
-                ]),
+                ])
+                ->required(),
+
+            Forms\Components\TextInput::make('base_imponible')
+                ->required()
+                ->numeric(),
+
+            Forms\Components\TextInput::make('iva_total')
+                ->required()
+                ->numeric(),
+
+            Forms\Components\TextInput::make('irpf_total')
+                ->required()
+                ->numeric(),
+
+            Forms\Components\TextInput::make('total')
+                ->required()
+                ->numeric(),
         ]);
     }
 

--- a/database/migrations/2025_08_07_000250_create_facturas_tables.php
+++ b/database/migrations/2025_08_07_000250_create_facturas_tables.php
@@ -33,8 +33,9 @@ return new class extends Migration
             $table->string('descripcion');
             $table->integer('cantidad')->default(1);
             $table->decimal('precio_unitario', 12, 2)->default(0);
-            $table->decimal('iva', 5, 2)->default(21.00); // porcentaje
-            $table->decimal('total_linea', 12, 2)->default(0);
+            $table->decimal('iva_porcentaje', 5, 2)->default(21);
+            $table->decimal('irpf_porcentaje', 5, 2)->nullable();
+            $table->decimal('subtotal', 14, 2)->default(0);
             $table->timestamps();
         });
     }

--- a/database/migrations/2025_08_08_000250_update_factura_productos_table.php
+++ b/database/migrations/2025_08_08_000250_update_factura_productos_table.php
@@ -21,10 +21,24 @@ return new class extends Migration {
             $table->foreignId('producto_id')->nullable()->change();
             $table->decimal('cantidad', 12, 3)->default(1)->change();
 
-            // add new tax and subtotal columns
-            $table->decimal('iva_porcentaje', 5, 2)->default(21);
-            $table->decimal('irpf_porcentaje', 5, 2)->nullable();
-            $table->decimal('subtotal', 14, 2)->default(0);
+            // remove obsolete columns
+            if (Schema::hasColumn('factura_productos', 'iva')) {
+                $table->dropColumn('iva');
+            }
+            if (Schema::hasColumn('factura_productos', 'total_linea')) {
+                $table->dropColumn('total_linea');
+            }
+
+            // add new tax and subtotal columns if missing
+            if (!Schema::hasColumn('factura_productos', 'iva_porcentaje')) {
+                $table->decimal('iva_porcentaje', 5, 2)->default(21);
+            }
+            if (!Schema::hasColumn('factura_productos', 'irpf_porcentaje')) {
+                $table->decimal('irpf_porcentaje', 5, 2)->nullable();
+            }
+            if (!Schema::hasColumn('factura_productos', 'subtotal')) {
+                $table->decimal('subtotal', 14, 2)->default(0);
+            }
         });
     }
 
@@ -32,6 +46,8 @@ return new class extends Migration {
     {
         Schema::table('factura_productos', function (Blueprint $table) {
             $table->dropColumn(['iva_porcentaje', 'irpf_porcentaje', 'subtotal']);
+            $table->decimal('iva', 5, 2)->default(21);
+            $table->decimal('total_linea', 12, 2)->default(0);
             $table->unsignedBigInteger('producto_id')->nullable(false)->change();
             $table->integer('cantidad')->default(1)->change();
             $table->unique(['factura_id', 'producto_id']);


### PR DESCRIPTION
## Summary
- add full Factura form with client, numbering and totals with required numeric validation
- drop obsolete `iva` and `total_linea` columns and introduce `iva_porcentaje`, `irpf_porcentaje`, `subtotal`
- update factura product migration to remove old columns and restore them on rollback

## Testing
- `composer install --no-interaction --no-progress` *(fails: CONNECT tunnel failed 403)*
- `composer test` *(fails: vendor/autoload.php not found)*

------
https://chatgpt.com/codex/tasks/task_e_6895c0d7e97c83219d6b7dbd25a26a62