### PR TITLE
feat: add actuacion productos

### DIFF
--- a/app/Filament/Resources/ActuacionResource.php
+++ b/app/Filament/Resources/ActuacionResource.php
@@ -5,6 +5,7 @@ namespace App\Filament\Resources;
 use App\Filament\Resources\ActuacionResource\Pages;
 use App\Models\Actuacion;
 use App\Models\Cliente;
+use App\Filament\Resources\ActuacionResource\RelationManagers\ProductosRelationManager;
 use Filament\Forms;
 use Filament\Forms\Form;
 use Filament\Resources\Resource;
@@ -96,14 +97,21 @@ class ActuacionResource extends Resource
         return $query;
     }
 
+    public static function getRelations(): array
+    {
+        return [
+            ProductosRelationManager::class,
+        ];
+    }
+
     public static function getPages(): array
-{
-    return [
-        'index'  => Pages\ListActuaciones::route('/'),
-        'create' => Pages\CreateActuacion::route('/create'),
-        'edit'   => Pages\EditActuacion::route('/{record}/edit'),
-    ];
-}
-	
-	public static function canCreate(): bool { return true; }
+    {
+        return [
+            'index'  => Pages\ListActuaciones::route('/'),
+            'create' => Pages\CreateActuacion::route('/create'),
+            'edit'   => Pages\EditActuacion::route('/{record}/edit'),
+        ];
+    }
+
+    public static function canCreate(): bool { return true; }
 }

--- a/app/Filament/Resources/ActuacionResource/RelationManagers/ProductosRelationManager.php
+++ b/app/Filament/Resources/ActuacionResource/RelationManagers/ProductosRelationManager.php
@@ -1,0 +1,75 @@
+<?php
+
+namespace App\Filament\Resources\ActuacionResource\RelationManagers;
+
+use App\Models\Producto;
+use Filament\Forms;
+use Filament\Forms\Form;
+use Filament\Resources\RelationManagers\RelationManager;
+use Filament\Tables;
+use Filament\Tables\Table;
+
+class ProductosRelationManager extends RelationManager
+{
+    protected static string $relationship = 'productos';
+
+    public function form(Form $form): Form
+    {
+        return $form->schema([
+            Forms\Components\Select::make('producto_id')
+                ->relationship('producto', 'nombre')
+                ->searchable()
+                ->label('Producto'),
+            Forms\Components\TextInput::make('descripcion')
+                ->required(),
+            Forms\Components\TextInput::make('cantidad')
+                ->numeric()
+                ->default(1)
+                ->required(),
+            Forms\Components\TextInput::make('precio_unitario')
+                ->numeric()
+                ->default(0)
+                ->required(),
+            Forms\Components\TextInput::make('iva_porcentaje')
+                ->numeric()
+                ->default(21)
+                ->required(),
+            Forms\Components\TextInput::make('irpf_porcentaje')
+                ->numeric()
+                ->nullable(),
+            Forms\Components\TextInput::make('subtotal')
+                ->numeric()
+                ->default(0)
+                ->required(),
+        ]);
+    }
+
+    public function table(Table $table): Table
+    {
+        return $table->columns([
+            Tables\Columns\TextColumn::make('producto.nombre')
+                ->label('Producto')
+                ->searchable(),
+            Tables\Columns\TextColumn::make('descripcion')
+                ->searchable(),
+            Tables\Columns\TextColumn::make('cantidad'),
+            Tables\Columns\TextColumn::make('precio_unitario')
+                ->money('eur'),
+            Tables\Columns\TextColumn::make('iva_porcentaje'),
+            Tables\Columns\TextColumn::make('irpf_porcentaje'),
+            Tables\Columns\TextColumn::make('subtotal')
+                ->money('eur'),
+        ])
+        ->headerActions([
+            Tables\Actions\CreateAction::make(),
+        ])
+        ->actions([
+            Tables\Actions\EditAction::make(),
+            Tables\Actions\DeleteAction::make(),
+        ])
+        ->bulkActions([
+            Tables\Actions\DeleteBulkAction::make(),
+        ]);
+    }
+}
+

--- a/app/Models/Actuacion.php
+++ b/app/Models/Actuacion.php
@@ -15,6 +15,7 @@ class Actuacion extends Model
 
     public function cliente() { return $this->belongsTo(Cliente::class); }
     public function pedidos() { return $this->hasMany(Pedido::class); }
+    public function productos() { return $this->hasMany(ActuacionProducto::class); }
     public function facturas() { return $this->belongsToMany(Factura::class, 'actuacion_factura'); }
 
     public function scopeMine($query)

--- a/app/Models/ActuacionProducto.php
+++ b/app/Models/ActuacionProducto.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class ActuacionProducto extends Model
+{
+    use HasFactory;
+
+    protected $table = 'actuacion_productos';
+
+    protected $fillable = [
+        'actuacion_id',
+        'producto_id',
+        'descripcion',
+        'cantidad',
+        'precio_unitario',
+        'iva_porcentaje',
+        'irpf_porcentaje',
+        'subtotal',
+    ];
+
+    public function actuacion()
+    {
+        return $this->belongsTo(Actuacion::class);
+    }
+
+    public function producto()
+    {
+        return $this->belongsTo(Producto::class);
+    }
+}
+

--- a/database/migrations/2025_08_09_000200_create_actuacion_productos_table.php
+++ b/database/migrations/2025_08_09_000200_create_actuacion_productos_table.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration {
+    public function up(): void
+    {
+        if (!Schema::hasTable('actuacion_productos')) {
+            Schema::create('actuacion_productos', function (Blueprint $table) {
+                $table->id();
+                $table->foreignId('actuacion_id')->constrained('actuaciones')->cascadeOnUpdate()->cascadeOnDelete();
+                $table->foreignId('producto_id')->nullable()->constrained('productos')->cascadeOnUpdate()->nullOnDelete();
+                $table->string('descripcion');
+                $table->decimal('cantidad', 12, 3)->default(1);
+                $table->decimal('precio_unitario', 12, 2)->default(0);
+                $table->decimal('iva_porcentaje', 5, 2)->default(21);
+                $table->decimal('irpf_porcentaje', 5, 2)->nullable();
+                $table->decimal('subtotal', 14, 2)->default(0);
+                $table->timestamps();
+                $table->index(['actuacion_id']);
+            });
+        }
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('actuacion_productos');
+    }
+};
+


### PR DESCRIPTION
## Summary
- add `actuacion_productos` migration and model with relationships
- wire up actuacion products relation manager in Filament
- expose actuacion->productos relationship

## Testing
- `composer test` *(fails: require(/workspace/fappv1/vendor/autoload.php): Failed to open stream: No such file or directory)*
- `composer install` *(fails: Failed to download symfony/polyfill-ctype from dist: curl error 56 ... CONNECT tunnel failed, response 403)*

------
https://chatgpt.com/codex/tasks/task_e_6895c2b18a2c8321b699586e5b7db072