### PR TITLE
Add user relationship to models

### DIFF
--- a/app/Models/Actuacion.php
+++ b/app/Models/Actuacion.php
@@ -13,6 +13,7 @@ class Actuacion extends Model
         'usuario_id','cliente_id','codigo','fecha_inicio','fecha_fin','estado','notas'
     ];
 
+    public function user() { return $this->belongsTo(User::class, 'usuario_id'); }
     public function cliente() { return $this->belongsTo(Cliente::class); }
     public function pedidos() { return $this->hasMany(Pedido::class); }
     public function productos() { return $this->hasMany(ActuacionProducto::class); }

--- a/app/Models/Cliente.php
+++ b/app/Models/Cliente.php
@@ -15,6 +15,11 @@ class Cliente extends Model
         'usuario_id', 'nombre', 'cif', 'email', 'telefono', 'direccion'
     ];
 
+    public function user()
+    {
+        return $this->belongsTo(User::class, 'usuario_id');
+    }
+
     public function scopeMine($query)
     {
         $user = auth()->user();

--- a/app/Models/Factura.php
+++ b/app/Models/Factura.php
@@ -15,6 +15,7 @@ class Factura extends Model
         'base_imponible','iva_total','irpf_total','total'
     ];
 
+    public function user() { return $this->belongsTo(User::class, 'usuario_id'); }
     public function cliente() { return $this->belongsTo(Cliente::class); }
     public function presupuesto() { return $this->belongsTo(Presupuesto::class); }
     public function lineas() { return $this->hasMany(FacturaProducto::class); }

--- a/app/Models/Pedido.php
+++ b/app/Models/Pedido.php
@@ -14,6 +14,7 @@ class Pedido extends Model
         'base_imponible','iva_total','irpf_total','total'
     ];
 
+    public function user() { return $this->belongsTo(User::class, 'usuario_id'); }
     public function cliente() { return $this->belongsTo(Cliente::class); }
     public function actuacion() { return $this->belongsTo(Actuacion::class); }
     public function presupuesto() { return $this->belongsTo(Presupuesto::class); }

--- a/app/Models/Presupuesto.php
+++ b/app/Models/Presupuesto.php
@@ -14,8 +14,22 @@ class Presupuesto extends Model
         'base_imponible','iva_total','irpf_total','total'
     ];
 
+    public function user()
+    {
+        return $this->belongsTo(User::class, 'usuario_id');
+    }
+
     public function cliente()
     {
         return $this->belongsTo(Cliente::class);
+    }
+
+    public function scopeMine($query)
+    {
+        $user = auth()->user();
+        if ($user && !$user->hasRole('admin')) {
+            $query->where('usuario_id', $user->id);
+        }
+        return $query;
     }
 }

--- a/app/Models/Producto.php
+++ b/app/Models/Producto.php
@@ -15,6 +15,11 @@ class Producto extends Model
         'usuario_id', 'nombre', 'descripcion', 'precio', 'iva_porcentaje', 'activo'
     ];
 
+    public function user()
+    {
+        return $this->belongsTo(User::class, 'usuario_id');
+    }
+
     public function scopeMine($query)
     {
         $user = auth()->user();


### PR DESCRIPTION
## Summary
- link Cliente, Producto, Presupuesto, Pedido, Actuacion, and Factura to their owning User via `user()`
- add consistent `scopeMine` to Presupuesto for user-specific queries

## Testing
- `composer test` *(fails: require vendor/autoload.php missing)*
- `composer install --no-interaction --no-progress` *(fails: CONNECT tunnel failed 403 while downloading dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_6895c42339588321b7024983419d0495