### PR TITLE
Update presupuestos schema and model

### DIFF
--- a/app/Models/Presupuesto.php
+++ b/app/Models/Presupuesto.php
@@ -14,6 +14,16 @@ class Presupuesto extends Model
         'base_imponible','iva_total','irpf_total','total'
     ];
 
+    protected $casts = [
+        'fecha' => 'date',
+        'validez_dias' => 'integer',
+        'activo' => 'boolean',
+        'base_imponible' => 'decimal:2',
+        'iva_total' => 'decimal:2',
+        'irpf_total' => 'decimal:2',
+        'total' => 'decimal:2',
+    ];
+
     public function user()
     {
         return $this->belongsTo(User::class, 'usuario_id');

--- a/database/migrations/2025_08_10_000000_update_presupuestos_table.php
+++ b/database/migrations/2025_08_10_000000_update_presupuestos_table.php
@@ -1,0 +1,42 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('presupuestos', function (Blueprint $table) {
+            $table->renameColumn('observaciones', 'notas');
+            $table->dropColumn('iva_porcentaje');
+        });
+
+        Schema::table('presupuestos', function (Blueprint $table) {
+            $table->enum('estado', ['borrador', 'enviado', 'aceptado', 'rechazado'])->default('borrador')->change();
+        });
+
+        Schema::table('presupuestos', function (Blueprint $table) {
+            $table->dropForeign(['cliente_id']);
+            $table->foreign('cliente_id')->references('id')->on('clientes')->cascadeOnUpdate()->restrictOnDelete();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('presupuestos', function (Blueprint $table) {
+            $table->renameColumn('notas', 'observaciones');
+            $table->decimal('iva_porcentaje', 5, 2)->default(21.00);
+        });
+
+        Schema::table('presupuestos', function (Blueprint $table) {
+            $table->enum('estado', ['pendiente', 'aceptado', 'rechazado'])->default('pendiente')->change();
+        });
+
+        Schema::table('presupuestos', function (Blueprint $table) {
+            $table->dropForeign(['cliente_id']);
+            $table->foreign('cliente_id')->references('id')->on('clientes')->cascadeOnUpdate()->cascadeOnDelete();
+        });
+    }
+};


### PR DESCRIPTION
## Summary
- rename `observaciones` to `notas`
- drop `iva_porcentaje`, adjust `estado` enum and restrict `cliente_id` FK
- add casts for key fields in `Presupuesto` model

## Testing
- `composer test` *(fails: Failed to open vendor/autoload.php; composer install blocked by network 403)*

------
https://chatgpt.com/codex/tasks/task_e_6895cceed7188321bd948821de1ade16