### PR TITLE
Refactor seeders for updated presupuesto fields

### DIFF
--- a/database/seeders/FappSeeder.php
+++ b/database/seeders/FappSeeder.php
@@ -49,8 +49,6 @@ DB::table('presupuestos')
         ], [
             'descripcion' => 'Hora de técnico',
             'precio' => 35,
-            'iva_porcentaje' => 21,
-            'activo' => true,
         ]);
 
         $p2 = Producto::firstOrCreate([
@@ -59,8 +57,6 @@ DB::table('presupuestos')
         ], [
             'descripcion' => 'Aire acondicionado split 3.0kW',
             'precio' => 599,
-            'iva_porcentaje' => 21,
-            'activo' => true,
         ]);
 
 
@@ -74,6 +70,13 @@ DB::table('presupuestos')
     ->delete();
 
         // Presupuesto demo con líneas
+        $manoObraSubtotal = 2 * 35;
+        $splitSubtotal = 1 * 599;
+        $base = $manoObraSubtotal + $splitSubtotal;
+        $ivaTotal = round($base * 0.21, 2);
+        $irpfTotal = 0;
+        $total = $base + $ivaTotal - $irpfTotal;
+
         $pres = Presupuesto::create([
             'usuario_id' => $admin->id,
             'cliente_id' => $c->id,
@@ -82,6 +85,10 @@ DB::table('presupuestos')
             'serie' => 'A',
             'estado' => 'borrador',
             'notas' => 'Presupuesto de ejemplo',
+            'base_imponible' => $base,
+            'iva_total' => $ivaTotal,
+            'irpf_total' => $irpfTotal,
+            'total' => $total,
         ]);
 
         PresupuestoProducto::create([
@@ -90,8 +97,7 @@ DB::table('presupuestos')
             'descripcion' => 'Mano de obra',
             'cantidad' => 2,
             'precio_unitario' => 35,
-            'iva_porcentaje' => 21,
-            'subtotal' => 70,
+            'subtotal' => $manoObraSubtotal,
         ]);
 
         PresupuestoProducto::create([
@@ -100,8 +106,10 @@ DB::table('presupuestos')
             'descripcion' => 'Split AC 3000fg',
             'cantidad' => 1,
             'precio_unitario' => 599,
-            'iva_porcentaje' => 21,
-            'subtotal' => 599,
+            'subtotal' => $splitSubtotal,
         ]);
+
+        // Semillas adicionales
+        $this->call(PresupuestoSeeder::class);
     }
 }

--- a/database/seeders/PresupuestoSeeder.php
+++ b/database/seeders/PresupuestoSeeder.php
@@ -20,20 +20,22 @@ class PresupuestoSeeder extends Seeder
         foreach (range(1, 15) as $i) {
             $cliente = $clientes->random();
             $base = rand(100, 2000);
-            $iva = 21;
-            $total = $base + ($base * $iva / 100);
+            $ivaTotal = round($base * 0.21, 2);
+            $irpfTotal = 0;
+            $total = $base + $ivaTotal - $irpfTotal;
 
             Presupuesto::create([
+                'usuario_id' => $cliente->usuario_id,
                 'serie' => 'PRES',
                 'numero' => $i,
                 'fecha' => now()->subDays(rand(0, 90)),
                 'cliente_id' => $cliente->id,
                 'base_imponible' => $base,
-                'iva_porcentaje' => $iva,
+                'iva_total' => $ivaTotal,
+                'irpf_total' => $irpfTotal,
                 'total' => $total,
-                'estado' => collect(['pendiente', 'aceptado', 'rechazado'])->random(),
-                'observaciones' => 'Observaciones del presupuesto ' . $i,
-                'activo' => 1,
+                'estado' => collect(['borrador', 'enviado', 'aceptado', 'rechazado'])->random(),
+                'notas' => 'Notas del presupuesto ' . $i,
             ]);
         }
     }


### PR DESCRIPTION
## Summary
- Drop legacy iva_porcentaje/activo usage in FappSeeder and compute budget totals
- Generate realistic presupuesto data without obsolete fields in PresupuestoSeeder

## Testing
- `composer test` *(fails: Failed to open required 'vendor/autoload.php')*
- `composer install` *(fails: failed to download packages from GitHub 403)*

------
https://chatgpt.com/codex/tasks/task_e_6895d5d0287883219a233e90e31438db