### PR TITLE
Restrict resources to current user scope

### DIFF
--- a/app/Filament/Resources/ActuacionResource.php
+++ b/app/Filament/Resources/ActuacionResource.php
@@ -91,10 +91,8 @@ class ActuacionResource extends Resource
     public static function getEloquentQuery(): Builder
     {
         $query = parent::getEloquentQuery();
-        if (auth()->check() && !auth()->user()->hasRole('admin')) {
-            $query->where('usuario_id', auth()->id());
-        }
-        return $query;
+
+        return auth()->user()?->hasRole('admin') ? $query : $query->mine();
     }
 
     public static function getRelations(): array

--- a/app/Filament/Resources/ClienteResource.php
+++ b/app/Filament/Resources/ClienteResource.php
@@ -14,6 +14,7 @@ use Filament\Tables\Actions\EditAction;
 use Filament\Tables\Actions\DeleteAction;
 use pxlrbt\FilamentExcel\Actions\Tables\ExportBulkAction;
 use App\Filament\Resources\ClienteResource\Pages;
+use Illuminate\Database\Eloquent\Builder;
 
 class ClienteResource extends Resource
 {
@@ -72,6 +73,13 @@ class ClienteResource extends Resource
                     DeleteBulkAction::make(),
                 ]),
             ]);
+    }
+
+    public static function getEloquentQuery(): Builder
+    {
+        $query = parent::getEloquentQuery();
+
+        return auth()->user()?->hasRole('admin') ? $query : $query->mine();
     }
 
     public static function getPages(): array

--- a/app/Filament/Resources/FacturaResource.php
+++ b/app/Filament/Resources/FacturaResource.php
@@ -11,6 +11,7 @@ use Filament\Resources\Resource;
 use Filament\Tables;
 use Filament\Tables\Table;
 use pxlrbt\FilamentExcel\Actions\Tables\ExportBulkAction;
+use Illuminate\Database\Eloquent\Builder;
 
 class FacturaResource extends Resource
 {
@@ -102,6 +103,13 @@ class FacturaResource extends Resource
                 ExportBulkAction::make(),
                 Tables\Actions\DeleteBulkAction::make(),
             ]);
+    }
+
+    public static function getEloquentQuery(): Builder
+    {
+        $query = parent::getEloquentQuery();
+
+        return auth()->user()?->hasRole('admin') ? $query : $query->mine();
     }
 
     public static function getPages(): array

--- a/app/Filament/Resources/PedidoResource.php
+++ b/app/Filament/Resources/PedidoResource.php
@@ -81,10 +81,8 @@ class PedidoResource extends Resource
     public static function getEloquentQuery(): Builder
     {
         $query = parent::getEloquentQuery();
-        if (auth()->check() && !auth()->user()->hasRole('admin')) {
-            $query->where('usuario_id', auth()->id());
-        }
-        return $query;
+
+        return auth()->user()?->hasRole('admin') ? $query : $query->mine();
     }
 
     public static function getPages(): array

--- a/app/Filament/Resources/PresupuestoResource.php
+++ b/app/Filament/Resources/PresupuestoResource.php
@@ -15,6 +15,7 @@ use Filament\Tables\Actions\EditAction;
 use Filament\Tables\Actions\DeleteAction;
 use pxlrbt\FilamentExcel\Actions\Tables\ExportBulkAction;
 use Illuminate\Validation\Rule;
+use Illuminate\Database\Eloquent\Builder;
 
 class PresupuestoResource extends Resource
 {
@@ -81,6 +82,13 @@ class PresupuestoResource extends Resource
                     DeleteBulkAction::make(),
                 ]),
             ]);
+    }
+
+    public static function getEloquentQuery(): Builder
+    {
+        $query = parent::getEloquentQuery();
+
+        return auth()->user()?->hasRole('admin') ? $query : $query->mine();
     }
 
     public static function getPages(): array

--- a/app/Filament/Resources/ProductoResource.php
+++ b/app/Filament/Resources/ProductoResource.php
@@ -71,6 +71,13 @@ class ProductoResource extends Resource
             ]);
     }
 
+    public static function getEloquentQuery(): Builder
+    {
+        $query = parent::getEloquentQuery();
+
+        return auth()->user()?->hasRole('admin') ? $query : $query->mine();
+    }
+
     public static function getPages(): array
     {
         return [


### PR DESCRIPTION
## Summary
- Limit resource queries to the authenticated user by default
- Allow admin users to bypass `mine` scope for global access

## Testing
- `composer test` *(fails: vendor autoload not found)*

------
https://chatgpt.com/codex/tasks/task_e_6895d5e225188321a435ac67a66c5176