### PR TITLE
Ensure estado validation matches enum definitions

### DIFF
--- a/app/Filament/Resources/ActuacionResource.php
+++ b/app/Filament/Resources/ActuacionResource.php
@@ -12,6 +12,7 @@ use Filament\Resources\Resource;
 use Filament\Tables;
 use Filament\Tables\Table;
 use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Validation\Rule;
 use pxlrbt\FilamentExcel\Actions\Tables\ExportBulkAction;
 
 class ActuacionResource extends Resource
@@ -53,7 +54,8 @@ class ActuacionResource extends Resource
                     'en_proceso'  => 'En proceso',
                     'completada'  => 'Completada',
                 ])
-                ->default('abierta'),
+                ->default('abierta')
+                ->rules(['required', Rule::in(['abierta', 'en_proceso', 'completada'])]),
 
             Forms\Components\Textarea::make('notas')
                 ->rows(3),

--- a/app/Filament/Resources/FacturaResource.php
+++ b/app/Filament/Resources/FacturaResource.php
@@ -10,6 +10,7 @@ use Filament\Forms\Form;
 use Filament\Resources\Resource;
 use Filament\Tables;
 use Filament\Tables\Table;
+use Illuminate\Validation\Rule;
 use pxlrbt\FilamentExcel\Actions\Tables\ExportBulkAction;
 
 class FacturaResource extends Resource
@@ -47,7 +48,8 @@ class FacturaResource extends Resource
                     'enviado' => 'Enviado',
                     'pagado' => 'Pagado',
                 ])
-                ->required(),
+                ->default('borrador')
+                ->rules(['required', Rule::in(['borrador', 'enviado', 'pagado'])]),
 
             Forms\Components\TextInput::make('base_imponible')
                 ->required()


### PR DESCRIPTION
## Summary
- validate Actuacion.estado against allowed values
- enforce Factura.estado options and default

## Testing
- `php -l app/Filament/Resources/ActuacionResource.php app/Filament/Resources/FacturaResource.php`
- `php artisan test` *(fails: vendor/autoload.php missing)*
- `composer install --no-interaction` *(fails: unable to clone GitHub repo, CONNECT tunnel failed 403)*

------
https://chatgpt.com/codex/tasks/task_e_6895d5ebccc883219a8fd558cb2f5841