### PR TITLE
Normalize monetary precision

### DIFF
--- a/app/Filament/Resources/ActuacionResource/RelationManagers/ProductosRelationManager.php
+++ b/app/Filament/Resources/ActuacionResource/RelationManagers/ProductosRelationManager.php
@@ -24,21 +24,26 @@ class ProductosRelationManager extends RelationManager
                 ->required(),
             Forms\Components\TextInput::make('cantidad')
                 ->numeric()
+                ->step(0.001)
                 ->default(1)
                 ->required(),
             Forms\Components\TextInput::make('precio_unitario')
                 ->numeric()
+                ->step(0.01)
                 ->default(0)
                 ->required(),
             Forms\Components\TextInput::make('iva_porcentaje')
                 ->numeric()
+                ->step(0.01)
                 ->default(21)
                 ->required(),
             Forms\Components\TextInput::make('irpf_porcentaje')
                 ->numeric()
+                ->step(0.01)
                 ->nullable(),
             Forms\Components\TextInput::make('subtotal')
                 ->numeric()
+                ->step(0.01)
                 ->default(0)
                 ->required(),
         ]);

--- a/app/Filament/Resources/FacturaResource.php
+++ b/app/Filament/Resources/FacturaResource.php
@@ -51,19 +51,23 @@ class FacturaResource extends Resource
 
             Forms\Components\TextInput::make('base_imponible')
                 ->required()
-                ->numeric(),
+                ->numeric()
+                ->step(0.01),
 
             Forms\Components\TextInput::make('iva_total')
                 ->required()
-                ->numeric(),
+                ->numeric()
+                ->step(0.01),
 
             Forms\Components\TextInput::make('irpf_total')
                 ->required()
-                ->numeric(),
+                ->numeric()
+                ->step(0.01),
 
             Forms\Components\TextInput::make('total')
                 ->required()
-                ->numeric(),
+                ->numeric()
+                ->step(0.01),
         ]);
     }
 

--- a/app/Filament/Resources/PedidoResource.php
+++ b/app/Filament/Resources/PedidoResource.php
@@ -35,10 +35,10 @@ class PedidoResource extends Resource
             Forms\Components\TextInput::make('serie')->required(),
             Forms\Components\TextInput::make('numero')->numeric()->required(),
             Forms\Components\DatePicker::make('fecha')->default(now())->required(),
-            Forms\Components\TextInput::make('base_imponible')->numeric()->required(),
-            Forms\Components\TextInput::make('iva_total')->numeric()->required(),
-            Forms\Components\TextInput::make('irpf_total')->numeric()->required(),
-            Forms\Components\TextInput::make('total')->numeric()->required(),
+            Forms\Components\TextInput::make('base_imponible')->numeric()->step(0.01)->required(),
+            Forms\Components\TextInput::make('iva_total')->numeric()->step(0.01)->required(),
+            Forms\Components\TextInput::make('irpf_total')->numeric()->step(0.01)->required(),
+            Forms\Components\TextInput::make('total')->numeric()->step(0.01)->required(),
 
             Forms\Components\Select::make('estado')
                 ->options([

--- a/app/Filament/Resources/PresupuestoResource.php
+++ b/app/Filament/Resources/PresupuestoResource.php
@@ -36,10 +36,10 @@ class PresupuestoResource extends Resource
                 ->relationship('cliente', 'nombre')
                 ->required()
                 ->searchable(),
-            Forms\Components\TextInput::make('base_imponible')->numeric()->required(),
-            Forms\Components\TextInput::make('iva_total')->numeric()->default(0),
-            Forms\Components\TextInput::make('irpf_total')->numeric()->default(0),
-            Forms\Components\TextInput::make('total')->numeric()->required(),
+            Forms\Components\TextInput::make('base_imponible')->numeric()->step(0.01)->required(),
+            Forms\Components\TextInput::make('iva_total')->numeric()->step(0.01)->default(0),
+            Forms\Components\TextInput::make('irpf_total')->numeric()->step(0.01)->default(0),
+            Forms\Components\TextInput::make('total')->numeric()->step(0.01)->required(),
             Forms\Components\Select::make('estado')
                 ->options([
                     'borrador' => 'Borrador',

--- a/app/Filament/Resources/ProductoResource.php
+++ b/app/Filament/Resources/ProductoResource.php
@@ -29,10 +29,12 @@ class ProductoResource extends Resource
 
             Forms\Components\TextInput::make('precio')
                 ->numeric()
+                ->step(0.01)
                 ->required(),
 
             Forms\Components\TextInput::make('iva_porcentaje')
                 ->numeric()
+                ->step(0.01)
                 ->default(21),
 
             Forms\Components\Toggle::make('activo')

--- a/database/migrations/2025_08_08_000000_create_presupuestos_table.php
+++ b/database/migrations/2025_08_08_000000_create_presupuestos_table.php
@@ -19,10 +19,10 @@ return new class extends Migration {
             $table->text('observaciones')->nullable();
             $table->unsignedTinyInteger('activo')->default(1);
             $table->decimal('iva_porcentaje', 5, 2)->default(21.00);
-            $table->decimal('base_imponible', 10, 2);
+            $table->decimal('base_imponible', 14, 2);
             $table->decimal('iva_total', 14, 2)->default(0);
             $table->decimal('irpf_total', 14, 2)->default(0);
-            $table->decimal('total', 10, 2);
+            $table->decimal('total', 14, 2);
             $table->timestamps();
             $table->unique(['usuario_id','serie','numero']);
             $table->unique(['serie', 'numero']);


### PR DESCRIPTION
## Summary
- Use DECIMAL(14,2) for monetary columns in the presupuestos migration
- Allow decimal entry for money fields with proper step values in Filament forms

## Testing
- `composer test` *(fails: vendor autoload not found)*
- `composer install` *(fails: GitHub authentication required)*

------
https://chatgpt.com/codex/tasks/task_e_6895d5e6cedc83219b18e180023d02f3