### PR TITLE
Filtrar clientes en presupuestos según usuario

### DIFF
--- a/app/Filament/Resources/PresupuestoResource.php
+++ b/app/Filament/Resources/PresupuestoResource.php
@@ -4,6 +4,7 @@ namespace App\Filament\Resources;
 
 use App\Filament\Resources\PresupuestoResource\Pages;
 use App\Models\Presupuesto;
+use App\Models\Cliente;
 use Filament\Forms;
 use Filament\Forms\Form;
 use Filament\Resources\Resource;
@@ -34,7 +35,14 @@ class PresupuestoResource extends Resource
             Forms\Components\DatePicker::make('fecha')->required(),
             Forms\Components\TextInput::make('validez_dias')->numeric()->nullable(),
             Forms\Components\Select::make('cliente_id')
-                ->relationship('cliente', 'nombre')
+                ->options(
+                    Cliente::query()
+                        ->when(
+                            auth()->check() && !auth()->user()->hasRole('admin'),
+                            fn ($q) => $q->where('usuario_id', auth()->id())
+                        )
+                        ->pluck('nombre', 'id')
+                )
                 ->required()
                 ->searchable(),
             Forms\Components\TextInput::make('base_imponible')->numeric()->step(0.01)->required(),

--- a/tests/Feature/PresupuestoResourceTest.php
+++ b/tests/Feature/PresupuestoResourceTest.php
@@ -1,0 +1,97 @@
+<?php
+
+namespace Tests\Feature;
+
+use Tests\TestCase;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use App\Models\User;
+use App\Models\Cliente;
+use Spatie\Permission\Models\Role;
+
+class PresupuestoResourceTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->artisan('migrate', ['--path' => 'database/migrations/fapp']);
+    }
+
+    public function test_admin_sees_all_clients_in_select(): void
+    {
+        Role::create(['name' => 'admin']);
+
+        $admin = User::factory()->create();
+        $admin->assignRole('admin');
+
+        $other = User::factory()->create();
+
+        Cliente::create([
+            'usuario_id' => $admin->id,
+            'nombre' => 'Admin Client',
+            'cif' => 'A1',
+            'email' => 'admin@example.com',
+            'telefono' => '111111111',
+            'direccion' => 'Street 1',
+        ]);
+
+        Cliente::create([
+            'usuario_id' => $other->id,
+            'nombre' => 'Other Client',
+            'cif' => 'B2',
+            'email' => 'other@example.com',
+            'telefono' => '222222222',
+            'direccion' => 'Street 2',
+        ]);
+
+        $this->actingAs($admin);
+
+        $options = Cliente::query()
+            ->when(
+                auth()->check() && !auth()->user()->hasRole('admin'),
+                fn ($q) => $q->where('usuario_id', auth()->id())
+            )
+            ->pluck('nombre', 'id');
+
+        $this->assertCount(2, $options);
+    }
+
+    public function test_non_admin_sees_only_their_clients_in_select(): void
+    {
+        Role::create(['name' => 'admin']);
+
+        $user = User::factory()->create();
+        $other = User::factory()->create();
+
+        Cliente::create([
+            'usuario_id' => $user->id,
+            'nombre' => 'My Client',
+            'cif' => 'C1',
+            'email' => 'my@example.com',
+            'telefono' => '333333333',
+            'direccion' => 'Street 3',
+        ]);
+
+        Cliente::create([
+            'usuario_id' => $other->id,
+            'nombre' => 'Other Client',
+            'cif' => 'D4',
+            'email' => 'other2@example.com',
+            'telefono' => '444444444',
+            'direccion' => 'Street 4',
+        ]);
+
+        $this->actingAs($user);
+
+        $options = Cliente::query()
+            ->when(
+                auth()->check() && !auth()->user()->hasRole('admin'),
+                fn ($q) => $q->where('usuario_id', auth()->id())
+            )
+            ->pluck('nombre', 'id');
+
+        $this->assertCount(1, $options);
+        $this->assertEquals(['My Client'], $options->values()->toArray());
+    }
+}


### PR DESCRIPTION
## Summary
- Filtra el select de clientes en Presupuesto para mostrar sólo los del usuario no administrador
- Añade pruebas para verificar visibilidad de clientes en el formulario

## Testing
- `composer install` *(falla: CONNECT tunnel failed, response 403)*
- `composer test` *(no se ejecuta: falta vendor/autoload.php)*

------
https://chatgpt.com/codex/tasks/task_e_6895e0157e4c8321bef7176f50993355