### PR TITLE
Split pedidos and actuaciones migration

### DIFF
--- a/database/migrations/fapp/2025_08_07_000200_create_actuaciones_table.php
+++ b/database/migrations/fapp/2025_08_07_000200_create_actuaciones_table.php
@@ -1,0 +1,30 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration {
+    public function up(): void
+    {
+        if (!Schema::hasTable('actuaciones')) {
+            Schema::create('actuaciones', function (Blueprint $table) {
+                $table->id();
+                $table->foreignId('usuario_id')->constrained('users')->cascadeOnUpdate()->restrictOnDelete();
+                $table->foreignId('cliente_id')->constrained('clientes')->cascadeOnUpdate()->restrictOnDelete();
+                $table->string('codigo')->nullable();
+                $table->date('fecha_inicio')->nullable();
+                $table->date('fecha_fin')->nullable();
+                $table->enum('estado', ['abierta','en_proceso','completada'])->default('abierta');
+                $table->text('notas')->nullable();
+                $table->timestamps();
+                $table->index(['usuario_id','cliente_id','estado','fecha_inicio']);
+            });
+        }
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('actuaciones');
+    }
+};

--- a/database/migrations/fapp/2025_08_07_000210_create_pedidos_table.php
+++ b/database/migrations/fapp/2025_08_07_000210_create_pedidos_table.php
@@ -3,25 +3,17 @@
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
+use RuntimeException;
 
 return new class extends Migration {
     public function up(): void
     {
-        if (!Schema::hasTable('actuaciones')) {
-            Schema::create('actuaciones', function (Blueprint $table) {
-                $table->id();
-                $table->foreignId('usuario_id')->constrained('users')->cascadeOnUpdate()->restrictOnDelete();
-                $table->foreignId('cliente_id')->constrained('clientes')->cascadeOnUpdate()->restrictOnDelete();
-                $table->string('codigo')->nullable();
-                $table->date('fecha_inicio')->nullable();
-                $table->date('fecha_fin')->nullable();
-                $table->enum('estado', ['abierta','en_proceso','completada'])->default('abierta');
-                $table->text('notas')->nullable();
-                $table->timestamps();
-                $table->index(['usuario_id','cliente_id','estado','fecha_inicio']);
-            });
+        if (!Schema::hasTable('presupuestos')) {
+            throw new RuntimeException('La tabla presupuestos debe existir antes de crear pedidos');
         }
-
+        if (!Schema::hasTable('actuaciones')) {
+            throw new RuntimeException('La tabla actuaciones debe existir antes de crear pedidos');
+        }
         if (!Schema::hasTable('pedidos')) {
             Schema::create('pedidos', function (Blueprint $table) {
                 $table->id();
@@ -43,27 +35,10 @@ return new class extends Migration {
                 $table->index(['usuario_id','cliente_id','estado','fecha']);
             });
         }
-
-        if (!Schema::hasTable('pedido_productos')) {
-            Schema::create('pedido_productos', function (Blueprint $table) {
-                $table->id();
-                $table->foreignId('pedido_id')->constrained('pedidos')->cascadeOnUpdate()->cascadeOnDelete();
-                $table->foreignId('producto_id')->nullable()->constrained('productos')->cascadeOnUpdate()->nullOnDelete();
-                $table->string('descripcion');
-                $table->decimal('cantidad', 12, 3)->default(1);
-                $table->decimal('precio_unitario', 12, 2)->default(0);
-                $table->decimal('iva_porcentaje', 5, 2)->default(21);
-                $table->decimal('irpf_porcentaje', 5, 2)->nullable();
-                $table->decimal('subtotal', 14, 2)->default(0);
-                $table->timestamps();
-                $table->index(['pedido_id']);
-            });
-        }
     }
+
     public function down(): void
     {
-        Schema::dropIfExists('pedido_productos');
         Schema::dropIfExists('pedidos');
-        Schema::dropIfExists('actuaciones');
     }
 };

--- a/database/migrations/fapp/2025_08_07_000220_create_pedido_productos_table.php
+++ b/database/migrations/fapp/2025_08_07_000220_create_pedido_productos_table.php
@@ -1,0 +1,38 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+use RuntimeException;
+
+return new class extends Migration {
+    public function up(): void
+    {
+        if (!Schema::hasTable('pedidos')) {
+            throw new RuntimeException('La tabla pedidos debe existir antes de crear pedido_productos');
+        }
+        if (!Schema::hasTable('productos')) {
+            throw new RuntimeException('La tabla productos debe existir antes de crear pedido_productos');
+        }
+        if (!Schema::hasTable('pedido_productos')) {
+            Schema::create('pedido_productos', function (Blueprint $table) {
+                $table->id();
+                $table->foreignId('pedido_id')->constrained('pedidos')->cascadeOnUpdate()->cascadeOnDelete();
+                $table->foreignId('producto_id')->nullable()->constrained('productos')->cascadeOnUpdate()->nullOnDelete();
+                $table->string('descripcion');
+                $table->decimal('cantidad', 12, 3)->default(1);
+                $table->decimal('precio_unitario', 12, 2)->default(0);
+                $table->decimal('iva_porcentaje', 5, 2)->default(21);
+                $table->decimal('irpf_porcentaje', 5, 2)->nullable();
+                $table->decimal('subtotal', 14, 2)->default(0);
+                $table->timestamps();
+                $table->index(['pedido_id']);
+            });
+        }
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('pedido_productos');
+    }
+};


### PR DESCRIPTION
## Summary
- split original pedidos/actuaciones migration into three migrations for actuaciones, pedidos, and pedido_productos
- ensure dependent tables exist before creating pedidos and pedido_productos

## Testing
- `vendor/bin/phpunit` *(fails: No such file or directory)*
- `composer install --no-interaction` *(fails: CONNECT tunnel failed, response 403)*

------
https://chatgpt.com/codex/tasks/task_e_689696b8362883219ebdd86fe3ff7919