### PR TITLE
feat: add budget management module

### DIFF
--- a/app/Filament/Resources/BudgetResource.php
+++ b/app/Filament/Resources/BudgetResource.php
@@ -1,0 +1,96 @@
+<?php
+
+namespace App\Filament\Resources;
+
+use App\Filament\Resources\BudgetResource\Pages;
+use App\Models\Budget;
+use Filament\Forms;
+use Filament\Forms\Form;
+use Filament\Resources\Resource;
+use Filament\Tables;
+use Filament\Tables\Table;
+use Filament\Tables\Actions\EditAction;
+use Filament\Tables\Actions\DeleteAction;
+use Filament\Tables\Actions\BulkActionGroup;
+use Filament\Tables\Actions\DeleteBulkAction;
+use pxlrbt\FilamentExcel\Actions\Tables\ExportAction;
+use pxlrbt\FilamentExcel\Actions\Tables\ExportBulkAction;
+
+class BudgetResource extends Resource
+{
+    protected static ?string $model = Budget::class;
+
+    protected static ?string $navigationIcon = 'heroicon-o-wallet';
+    protected static ?string $navigationLabel = 'Presupuestos';
+    protected static ?string $pluralLabel = 'Presupuestos';
+    protected static ?string $modelLabel = 'Presupuesto';
+    protected static ?int $navigationSort = 70;
+
+    public static function form(Form $form): Form
+    {
+        return $form->schema([
+            Forms\Components\Hidden::make('usuario_id')
+                ->default(fn () => auth()->id()),
+
+            Forms\Components\TextInput::make('nombre')
+                ->label('Nombre')
+                ->required(),
+
+            Forms\Components\TextInput::make('monto')
+                ->label('Monto')
+                ->numeric()
+                ->required(),
+
+            Forms\Components\Textarea::make('descripcion')
+                ->label('Descripción')
+                ->columnSpanFull(),
+
+            Forms\Components\Toggle::make('activo')
+                ->label('Activo')
+                ->default(true),
+        ]);
+    }
+
+    public static function table(Table $table): Table
+    {
+        return $table
+            ->columns([
+                Tables\Columns\TextColumn::make('nombre')
+                    ->label('Nombre')
+                    ->searchable()
+                    ->sortable(),
+                Tables\Columns\TextColumn::make('monto')
+                    ->label('Monto')
+                    ->sortable(),
+                Tables\Columns\IconColumn::make('activo')
+                    ->label('Activo')
+                    ->boolean(),
+                Tables\Columns\TextColumn::make('updated_at')
+                    ->label('Actualizado')
+                    ->dateTime('d/m/Y')
+                    ->sortable(),
+            ])
+            ->actions([
+                EditAction::make(),
+                DeleteAction::make(),
+            ])
+            ->bulkActions([
+                BulkActionGroup::make([
+                    DeleteBulkAction::make(),
+                    ExportBulkAction::make(),
+                ]),
+            ])
+            ->headerActions([
+                ExportAction::make(),
+            ]);
+    }
+
+    public static function getPages(): array
+    {
+        return [
+            'index' => Pages\ListBudgets::route('/'),
+            'create' => Pages\CreateBudget::route('/create'),
+            'edit' => Pages\EditBudget::route('/{record}/edit'),
+        ];
+    }
+}

--- a/app/Filament/Resources/BudgetResource/Pages/CreateBudget.php
+++ b/app/Filament/Resources/BudgetResource/Pages/CreateBudget.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace App\Filament\Resources\BudgetResource\Pages;
+
+use App\Filament\Resources\BudgetResource;
+use Filament\Resources\Pages\CreateRecord;
+
+class CreateBudget extends CreateRecord
+{
+    protected static string $resource = BudgetResource::class;
+}

--- a/app/Filament/Resources/BudgetResource/Pages/EditBudget.php
+++ b/app/Filament/Resources/BudgetResource/Pages/EditBudget.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace App\Filament\Resources\BudgetResource\Pages;
+
+use App\Filament\Resources\BudgetResource;
+use Filament\Resources\Pages\EditRecord;
+
+class EditBudget extends EditRecord
+{
+    protected static string $resource = BudgetResource::class;
+}

--- a/app/Filament/Resources/BudgetResource/Pages/ListBudgets.php
+++ b/app/Filament/Resources/BudgetResource/Pages/ListBudgets.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace App\Filament\Resources\BudgetResource\Pages;
+
+use App\Filament\Resources\BudgetResource;
+use Filament\Resources\Pages\ListRecords;
+
+class ListBudgets extends ListRecords
+{
+    protected static string $resource = BudgetResource::class;
+}

--- a/app/Models/Budget.php
+++ b/app/Models/Budget.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use App\Models\Concerns\HasTenant;
+
+class Budget extends Model
+{
+    use HasFactory;
+    use HasTenant;
+
+    protected $table = 'budgets';
+
+    protected $fillable = [
+        'usuario_id',
+        'nombre',
+        'monto',
+        'descripcion',
+        'activo',
+    ];
+
+    protected $casts = [
+        'monto' => 'decimal:2',
+        'activo' => 'boolean',
+    ];
+
+    public function user()
+    {
+        return $this->belongsTo(User::class, 'usuario_id');
+    }
+}

--- a/database/migrations/2025_08_09_000400_create_budgets_table.php
+++ b/database/migrations/2025_08_09_000400_create_budgets_table.php
@@ -1,0 +1,26 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration {
+    public function up(): void
+    {
+        Schema::create('budgets', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('usuario_id')->constrained('users')->cascadeOnUpdate()->restrictOnDelete();
+            $table->string('nombre');
+            $table->decimal('monto', 14, 2);
+            $table->text('descripcion')->nullable();
+            $table->boolean('activo')->default(true);
+            $table->timestamps();
+            $table->index(['usuario_id', 'activo']);
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('budgets');
+    }
+};


### PR DESCRIPTION
## Summary
- add Budget model and migration for basic budget records
- expose budgets in Filament with list, create and edit pages

## Testing
- `composer install --no-interaction` (failed: CONNECT tunnel failed, response 403)
- `composer test` (fails: Failed opening required '/workspace/fappv1/vendor/autoload.php')


------
https://chatgpt.com/codex/tasks/task_e_68990c0e8a608321884675c157627e94