### PR TITLE
fix: correct clientes migration

### DIFF
--- a/database/migrations/fapp/2025_08_07_000020_create_clientes_table.php
+++ b/database/migrations/fapp/2025_08_07_000020_create_clientes_table.php
@@ -9,8 +9,8 @@ return new class extends Migration {
     {
         if (! Schema::hasTable('clientes')) {
             Schema::create('clientes', function (Blueprint $table) {
-                $table->bigIncrements('id'); // BIGINT UNSIGNED PK
-                $table->foreignId('id')
+                $table->id();
+                $table->foreignId('usuario_id')
                     ->constrained('users')
                     ->cascadeOnUpdate()
                     ->restrictOnDelete();


### PR DESCRIPTION
## Summary
- fix clientes migration to use usuario_id foreign key referencing users

## Testing
- `composer test` *(fails: vendor/autoload.php not found)*

------
https://chatgpt.com/codex/tasks/task_e_6899c444e34083219dc0c7df39ec71e5