### PR TITLE
Add new budget button to budget list

### DIFF
--- a/app/Filament/Resources/BudgetResource/Pages/ListBudgets.php
+++ b/app/Filament/Resources/BudgetResource/Pages/ListBudgets.php
@@ -3,9 +3,17 @@
 namespace App\Filament\Resources\BudgetResource\Pages;
 
 use App\Filament\Resources\BudgetResource;
+use Filament\Actions;
 use Filament\Resources\Pages\ListRecords;
 
 class ListBudgets extends ListRecords
 {
     protected static string $resource = BudgetResource::class;
+
+    protected function getHeaderActions(): array
+    {
+        return [
+            Actions\CreateAction::make()->label('Nuevo Presupuesto'),
+        ];
+    }
 }


### PR DESCRIPTION
## Summary
- enable creating budgets from the list with a "Nuevo Presupuesto" button

## Testing
- `composer install` *(fails: requires GitHub token)*
- `vendor/bin/phpunit` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_6899e05308a8832182ee5529b72b1ef4