### PR TITLE
Mirror presupuesto structure in budget tables

### DIFF
--- a/app/Filament/Resources/BudgetResource.php
+++ b/app/Filament/Resources/BudgetResource.php
@@ -3,9 +3,13 @@
 namespace App\Filament\Resources;
 
 use App\Filament\Resources\BudgetResource\Pages;
+use App\Models\Cliente;
 use App\Models\Budget;
+use App\Models\Producto;
 use Filament\Forms;
 use Filament\Forms\Form;
+use Filament\Forms\Get;
+use Filament\Forms\Set;
 use Filament\Resources\Resource;
 use Filament\Tables;
 use Filament\Tables\Table;
@@ -20,7 +24,7 @@ class BudgetResource extends Resource
 {
     protected static ?string $model = Budget::class;
 
-    protected static ?string $navigationIcon = 'heroicon-o-wallet';
+    protected static ?string $navigationIcon = 'heroicon-o-document-text';
     protected static ?string $navigationLabel = 'Presupuestos';
     protected static ?string $pluralLabel = 'Presupuestos';
     protected static ?string $modelLabel = 'Presupuesto';
@@ -29,25 +33,234 @@ class BudgetResource extends Resource
     public static function form(Form $form): Form
     {
         return $form->schema([
-            Forms\Components\Hidden::make('usuario_id')
-                ->default(fn () => auth()->id()),
+            // ENCABEZADO
+            Forms\Components\Section::make('Encabezado')
+                ->columns(4)
+                ->schema([
+                    Forms\Components\Hidden::make('usuario_id')
+                        ->default(fn () => auth()->id()),
 
-            Forms\Components\TextInput::make('nombre')
-                ->label('Nombre')
-                ->required(),
+                    Forms\Components\TextInput::make('serie')
+                        ->label('Serie')
+                        ->default(fn () => auth()->user()?->serie_presupuesto ?? 'A')
+                        ->disabled()
+                        ->dehydrated(),
 
-            Forms\Components\TextInput::make('monto')
-                ->label('Monto')
-                ->numeric()
-                ->required(),
+                    Forms\Components\TextInput::make('numero')
+                        ->label('Número')
+                        ->disabled()
+                        ->helperText('Se asigna automáticamente al guardar.')
+                        ->dehydrated(),
 
-            Forms\Components\Textarea::make('descripcion')
-                ->label('Descripción')
+                    Forms\Components\DatePicker::make('fecha')
+                        ->label('Fecha')
+                        ->default(today())
+                        ->required(),
+                ])
                 ->columnSpanFull(),
 
-            Forms\Components\Toggle::make('activo')
-                ->label('Activo')
-                ->default(true),
+            // CLIENTE Y CONDICIONES
+            Forms\Components\Section::make('Cliente y condiciones')
+                ->columns(6)
+                ->schema([
+                    Forms\Components\Select::make('cliente_id')
+                        ->label('Cliente')
+                        ->options(fn () =>
+                            Cliente::query()
+                                ->where('usuario_id', auth()->id())
+                                ->orderBy('nombre')
+                                ->pluck('nombre', 'id')
+                                ->toArray()
+                        )
+                        ->searchable()
+                        ->required()
+                        ->columnSpan(3),
+
+                    Forms\Components\TextInput::make('validez_dias')
+                        ->label('Validez (días)')
+                        ->numeric()
+                        ->default(30),
+
+                    Forms\Components\Select::make('estado')
+                        ->options([
+                            'borrador'  => 'Borrador',
+                            'enviado'   => 'Enviado',
+                            'aceptado'  => 'Aceptado',
+                            'rechazado' => 'Rechazado',
+                        ])
+                        ->default('borrador'),
+
+                    Forms\Components\Toggle::make('activo')
+                        ->label('Activo')
+                        ->default(true),
+                ])
+                ->columnSpanFull(),
+
+            // LÍNEAS
+            Forms\Components\Section::make('Líneas')
+                ->schema([
+                    Forms\Components\Repeater::make('lineas')
+                        ->relationship('lineas')
+                        ->defaultItems(1)
+                        ->createItemButtonLabel('Añadir línea')
+                        ->columns(12)
+                        ->afterStateHydrated(function ($state, Set $set) {
+                            static::pushTotalsFromLines(is_array($state) ? $state : [], $set);
+                        })
+                        ->afterStateUpdated(function ($state, Set $set) {
+                            static::pushTotalsFromLines(is_array($state) ? $state : [], $set);
+                        })
+                        ->schema([
+                            // Orden: producto, descripción, cantidad, precio, dto%, IVA%, subtotal
+                            Forms\Components\Select::make('producto_id')
+                                ->label('Producto')
+                                ->options(fn () =>
+                                    Producto::query()
+                                        ->where('usuario_id', auth()->id())
+                                        ->orderBy('nombre')
+                                        ->pluck('nombre', 'id')
+                                        ->toArray()
+                                )
+                                ->searchable()
+                                ->preload()
+                                ->live(onBlur: false)
+                                ->afterStateUpdated(function ($state, Set $set, Get $get) {
+                                    if ($state) {
+                                        $p = Producto::find($state);
+                                        if ($p) {
+                                            if (blank($get('descripcion'))) {
+                                                $set('descripcion', $p->nombre);
+                                            }
+                                            $precio = (float) $p->precio;
+                                            $iva    = (float) ($p->iva_porcentaje ?? 21);
+                                            $cant   = (float) ($get('cantidad') ?? 1);
+                                            $dto    = (float) ($get('descuento_porcentaje') ?? 0);
+
+                                            $set('precio_unitario', number_format($precio, 2, '.', ''));
+                                            $set('iva_porcentaje', $iva);
+                                            $set('descuento_porcentaje', $dto);
+
+                                            $bruto = $cant * $precio;
+                                            $neto  = $bruto - ($bruto * $dto / 100);
+                                            $set('subtotal', number_format($neto, 2, '.', ''));
+                                        }
+                                    }
+                                    static::pushTotals($get, $set);
+                                })
+                                ->columnSpan(2),
+
+                            Forms\Components\TextInput::make('descripcion')
+                                ->label('Descripción')
+                                ->required()
+                                ->columnSpan(4),
+
+                            Forms\Components\TextInput::make('cantidad')
+                                ->numeric()->minValue(0.001)->step('0.001')
+                                ->default(1)
+                                ->live(onBlur: false)
+                                ->afterStateUpdated(function ($state, Set $set, Get $get) {
+                                    $precio = (float) ($get('precio_unitario') ?? 0);
+                                    $dto    = (float) ($get('descuento_porcentaje') ?? 0);
+                                    $bruto  = ((float) $state) * $precio;
+                                    $neto   = $bruto - ($bruto * $dto / 100);
+                                    $set('subtotal', number_format($neto, 2, '.', ''));
+                                    static::pushTotals($get, $set);
+                                })
+                                ->columnSpan(1),
+
+                            Forms\Components\TextInput::make('precio_unitario')
+                                ->label('Precio')
+                                ->numeric()->minValue(0)->step('0.01')
+                                ->live(onBlur: false)
+                                ->afterStateUpdated(function ($state, Set $set, Get $get) {
+                                    $cant  = (float) ($get('cantidad') ?? 1);
+                                    $dto   = (float) ($get('descuento_porcentaje') ?? 0);
+                                    $bruto = $cant * (float) $state;
+                                    $neto  = $bruto - ($bruto * $dto / 100);
+                                    $set('subtotal', number_format($neto, 2, '.', ''));
+                                    static::pushTotals($get, $set);
+                                })
+                                ->formatStateUsing(fn ($state) => number_format((float) $state, 2, '.', ''))
+                                ->columnSpan(1),
+
+                            Forms\Components\TextInput::make('descuento_porcentaje')
+                                ->label('Dto %')
+                                ->numeric()->minValue(0)->maxValue(100)->step('0.01')
+                                ->default(0)
+                                ->live(onBlur: false)
+                                ->afterStateUpdated(function ($state, Set $set, Get $get) {
+                                    $cant  = (float) ($get('cantidad') ?? 1);
+                                    $precio= (float) ($get('precio_unitario') ?? 0);
+                                    $bruto = $cant * $precio;
+                                    $neto  = $bruto - ($bruto * ((float) $state) / 100);
+                                    $set('subtotal', number_format($neto, 2, '.', ''));
+                                    static::pushTotals($get, $set);
+                                })
+                                ->columnSpan(1),
+
+                            Forms\Components\TextInput::make('iva_porcentaje')
+                                ->label('IVA %')
+                                ->numeric()->minValue(0)->maxValue(21)->step('0.01')
+                                ->default(21)
+                                ->live(onBlur: false)
+                                ->afterStateUpdated(function ($state, Set $set, Get $get) {
+                                    static::pushTotals($get, $set);
+                                })
+                                ->columnSpan(1),
+
+                            Forms\Components\TextInput::make('subtotal')
+                                ->label('Subtotal')
+                                ->disabled()
+                                ->dehydrated()
+                                ->formatStateUsing(fn ($state) => number_format((float) $state, 2, '.', ''))
+                                ->columnSpan(2),
+
+                            Forms\Components\Textarea::make('notas_producto_linea')
+                                ->label('Notas')
+                                ->rows(2)
+                                ->columnSpan(12),
+                        ]),
+                ])
+                ->columnSpanFull(),
+
+            // TOTALES
+            Forms\Components\Section::make('Totales')
+                ->columns(5)
+                ->schema([
+                    Forms\Components\TextInput::make('base_imponible')
+                        ->label('Base')
+                        ->disabled()
+                        ->dehydrated(false)
+                        ->formatStateUsing(fn ($state) => number_format((float) $state, 2, '.', '')),
+                    Forms\Components\TextInput::make('descuento_total')
+                        ->label('Dto Total')
+                        ->disabled()
+                        ->dehydrated(false)
+                        ->formatStateUsing(fn ($state) => number_format((float) $state, 2, '.', '')),
+                    Forms\Components\TextInput::make('iva_total')
+                        ->label('IVA')
+                        ->disabled()
+                        ->dehydrated(false)
+                        ->formatStateUsing(fn ($state) => number_format((float) $state, 2, '.', '')),
+                    Forms\Components\TextInput::make('irpf_total')
+                        ->label('IRPF')
+                        ->disabled()
+                        ->dehydrated(false)
+                        ->formatStateUsing(fn ($state) => number_format((float) $state, 2, '.', '')),
+                    Forms\Components\TextInput::make('total')
+                        ->label('Total')
+                        ->disabled()
+                        ->dehydrated(false)
+                        ->formatStateUsing(fn ($state) => number_format((float) $state, 2, '.', '')),
+                ])
+                ->columnSpanFull(),
+
+            // NOTAS
+            Forms\Components\Section::make('Notas')
+                ->schema([
+                    Forms\Components\Textarea::make('notas')->rows(4)->columnSpanFull(),
+                ])
+                ->columnSpanFull(),
         ]);
     }
 
@@ -55,20 +268,21 @@ class BudgetResource extends Resource
     {
         return $table
             ->columns([
-                Tables\Columns\TextColumn::make('nombre')
-                    ->label('Nombre')
-                    ->searchable()
-                    ->sortable(),
-                Tables\Columns\TextColumn::make('monto')
-                    ->label('Monto')
-                    ->sortable(),
-                Tables\Columns\IconColumn::make('activo')
-                    ->label('Activo')
-                    ->boolean(),
-                Tables\Columns\TextColumn::make('updated_at')
-                    ->label('Actualizado')
-                    ->dateTime('d/m/Y')
-                    ->sortable(),
+                Tables\Columns\TextColumn::make('serie')->sortable(),
+                Tables\Columns\TextColumn::make('numero')->sortable(),
+                Tables\Columns\TextColumn::make('fecha')->date()->sortable(),
+                Tables\Columns\TextColumn::make('cliente.nombre')->label('Cliente')->sortable()->searchable(),
+                Tables\Columns\TextColumn::make('base_imponible')->money('EUR'),
+                Tables\Columns\TextColumn::make('descuento_total')->money('EUR'),
+                Tables\Columns\TextColumn::make('iva_total')->money('EUR'),
+                Tables\Columns\TextColumn::make('irpf_total')->money('EUR'),
+                Tables\Columns\TextColumn::make('total')->money('EUR'),
+                Tables\Columns\TextColumn::make('estado')->badge(),
+                Tables\Columns\IconColumn::make('activo')->boolean(),
+            ])
+            ->filters([])
+            ->headerActions([
+                ExportAction::make('export')->label('Exportar'),
             ])
             ->actions([
                 EditAction::make(),
@@ -76,21 +290,89 @@ class BudgetResource extends Resource
             ])
             ->bulkActions([
                 BulkActionGroup::make([
-                    DeleteBulkAction::make(),
                     ExportBulkAction::make(),
+                    DeleteBulkAction::make(),
                 ]),
-            ])
-            ->headerActions([
-                ExportAction::make(),
             ]);
     }
 
     public static function getPages(): array
     {
         return [
-            'index' => Pages\ListBudgets::route('/'),
+            'index'  => Pages\ListBudgets::route('/'),
             'create' => Pages\CreateBudget::route('/create'),
-            'edit' => Pages\EditBudget::route('/{record}/edit'),
+            'edit'   => Pages\EditBudget::route('/{record}/edit'),
         ];
+    }
+
+    // ================= Helpers internos (SIN archivos externos) =================
+
+    /** Obtiene el array de líneas desde el contexto del Repeater. */
+    protected static function linesFrom(Get $get): array
+    {
+        foreach (['lineas', '../lineas', '../../lineas', '../../../lineas'] as $path) {
+            $v = $get($path);
+            if (is_array($v)) {
+                return $v;
+            }
+        }
+        return [];
+    }
+
+    /** Recalcula y vuelca los totales en el formulario, leyendo las líneas desde $get. */
+    protected static function pushTotals(Get $get, Set $set): void
+    {
+        static::pushTotalsFromLines(static::linesFrom($get), $set);
+    }
+
+    /** Recalcula y vuelca totales dado un array de líneas. */
+    protected static function pushTotalsFromLines(array $lineas, Set $set): void
+    {
+        [$base, $dto, $iva, $irpf, $total] = static::calcTotals($lineas);
+
+        $set('base_imponible', number_format($base, 2, '.', ''));
+        $set('descuento_total', number_format($dto, 2, '.', ''));
+        $set('iva_total', number_format($iva, 2, '.', ''));
+        $set('irpf_total', number_format($irpf, 2, '.', ''));
+        $set('total', number_format($total, 2, '.', ''));
+    }
+
+    /**
+     * Cálculo puro de totales (en la propia clase, sin servicios externos).
+     * Base = suma de subtotales (netos con dto).
+     * Dto total (€) = suma(bruto - subtotal) por línea.
+     * IVA total = suma(subtotal * iva% / 100).
+     * IRPF total = suma(subtotal * irpf% / 100) — si no hay, se asume 0.
+     * Total = Base + IVA - IRPF.
+     */
+    protected static function calcTotals(array $lineas): array
+    {
+        $base = 0.0;
+        $dtoTotal = 0.0;
+        $ivaTotal = 0.0;
+        $irpfTotal = 0.0;
+
+        foreach ($lineas as $l) {
+            $cantidad = (float) ($l['cantidad'] ?? 0);
+            $precio   = (float) ($l['precio_unitario'] ?? 0);
+            $dtoPct   = (float) ($l['descuento_porcentaje'] ?? 0);
+            $ivaPct   = (float) ($l['iva_porcentaje'] ?? 0);
+            $irpfPct  = (float) ($l['irpf_porcentaje'] ?? 0);
+
+            $bruto = $cantidad * $precio;
+
+            $subtotal = isset($l['subtotal']) && $l['subtotal'] !== '' && $l['subtotal'] !== null
+                ? (float) $l['subtotal']
+                : round($bruto - ($bruto * $dtoPct / 100), 2);
+
+            $base     += $subtotal;
+            $dtoTotal += max($bruto - $subtotal, 0);
+            $ivaTotal += round($subtotal * $ivaPct / 100, 2);
+            $irpfTotal+= round($subtotal * $irpfPct / 100, 2);
+        }
+
+        $total = $base + $ivaTotal - $irpfTotal;
+
+        return [round($base, 2), round($dtoTotal, 2), round($ivaTotal, 2), round($irpfTotal, 2), round($total, 2)];
     }
 }

--- a/app/Models/Budget.php
+++ b/app/Models/Budget.php
@@ -15,19 +15,42 @@ class Budget extends Model
 
     protected $fillable = [
         'usuario_id',
-        'nombre',
-        'monto',
-        'descripcion',
+        'cliente_id',
+        'fecha',
+        'numero',
+        'serie',
+        'estado',
+        'validez_dias',
+        'notas',
         'activo',
+        'base_imponible',
+        'iva_total',
+        'irpf_total',
+        'total',
     ];
 
     protected $casts = [
-        'monto' => 'decimal:2',
-        'activo' => 'boolean',
+        'fecha'          => 'date',
+        'validez_dias'   => 'integer',
+        'activo'         => 'boolean',
+        'base_imponible' => 'decimal:2',
+        'iva_total'      => 'decimal:2',
+        'irpf_total'     => 'decimal:2',
+        'total'          => 'decimal:2',
     ];
 
     public function user()
     {
         return $this->belongsTo(User::class, 'usuario_id');
+    }
+
+    public function cliente()
+    {
+        return $this->belongsTo(Cliente::class);
+    }
+
+    public function lineas()
+    {
+        return $this->hasMany(BudgetProduct::class, 'budget_id');
     }
 }

--- a/app/Models/BudgetProduct.php
+++ b/app/Models/BudgetProduct.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+
+class BudgetProduct extends Model
+{
+    protected $table = 'budget_products';
+
+    protected $fillable = [
+        'budget_id',
+        'producto_id',
+        'descripcion',
+        'cantidad',
+        'precio_unitario',
+        'iva_porcentaje',
+        'irpf_porcentaje',
+        'subtotal',
+    ];
+
+    public function budget()
+    {
+        return $this->belongsTo(Budget::class, 'budget_id');
+    }
+
+    public function producto()
+    {
+        return $this->belongsTo(Producto::class, 'producto_id');
+    }
+}

--- a/database/migrations/2025_08_09_000400_create_budgets_table.php
+++ b/database/migrations/2025_08_09_000400_create_budgets_table.php
@@ -7,20 +7,47 @@ use Illuminate\Support\Facades\Schema;
 return new class extends Migration {
     public function up(): void
     {
-        Schema::create('budgets', function (Blueprint $table) {
-            $table->id();
-            $table->foreignId('usuario_id')->constrained('users')->cascadeOnUpdate()->restrictOnDelete();
-            $table->string('nombre');
-            $table->decimal('monto', 14, 2);
-            $table->text('descripcion')->nullable();
-            $table->boolean('activo')->default(true);
-            $table->timestamps();
-            $table->index(['usuario_id', 'activo']);
-        });
+        if (!Schema::hasTable('budgets')) {
+            Schema::create('budgets', function (Blueprint $table) {
+                $table->id();
+                $table->foreignId('usuario_id')->constrained('users')->cascadeOnUpdate()->restrictOnDelete();
+                $table->foreignId('cliente_id')->constrained('clientes')->cascadeOnUpdate()->restrictOnDelete();
+                $table->date('fecha')->nullable();
+                $table->unsignedBigInteger('numero')->default(0);
+                $table->string('serie', 20)->default('A');
+                $table->enum('estado', ['borrador','enviado','aceptado','rechazado'])->default('borrador');
+                $table->unsignedInteger('validez_dias')->nullable();
+                $table->text('notas')->nullable();
+                $table->boolean('activo')->default(true);
+                $table->decimal('base_imponible', 14, 2)->default(0);
+                $table->decimal('iva_total', 14, 2)->default(0);
+                $table->decimal('irpf_total', 14, 2)->default(0);
+                $table->decimal('total', 14, 2)->default(0);
+                $table->timestamps();
+                $table->unique(['usuario_id','serie','numero']);
+                $table->index(['usuario_id','cliente_id','estado','fecha','activo']);
+            });
+        }
+        if (!Schema::hasTable('budget_products')) {
+            Schema::create('budget_products', function (Blueprint $table) {
+                $table->id();
+                $table->foreignId('budget_id')->constrained('budgets')->cascadeOnUpdate()->cascadeOnDelete();
+                $table->foreignId('producto_id')->nullable()->constrained('productos')->cascadeOnUpdate()->nullOnDelete();
+                $table->string('descripcion');
+                $table->decimal('cantidad', 12, 3)->default(1);
+                $table->decimal('precio_unitario', 12, 2)->default(0);
+                $table->decimal('iva_porcentaje', 5, 2)->default(21);
+                $table->decimal('irpf_porcentaje', 5, 2)->nullable();
+                $table->decimal('subtotal', 14, 2)->default(0);
+                $table->timestamps();
+                $table->index(['budget_id']);
+            });
+        }
     }
 
     public function down(): void
     {
+        Schema::dropIfExists('budget_products');
         Schema::dropIfExists('budgets');
     }
 };


### PR DESCRIPTION
## Summary
- Align `budgets` schema with existing `presupuestos` table and add `budget_products`
- Expand Budget model with presupuesto-like fields and relationships
- Rework Budget Filament resource to use new structure

## Testing
- `composer test` *(fails: require(/workspace/fappv1/vendor/autoload.php): No such file or directory)*
- `composer install` *(fails: curl error 56 while downloading https://api.github.com/...: CONNECT tunnel failed)*

------
https://chatgpt.com/codex/tasks/task_e_689a3acc532083218447287d5af986c4