### PR TITLE
Add budget products schema table

### DIFF
--- a/fappv1_schema.sql
+++ b/fappv1_schema.sql
@@ -234,6 +234,26 @@ CREATE TABLE budgets (
         ON UPDATE CASCADE ON DELETE RESTRICT
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 
+-- Budget products
+CREATE TABLE budget_products (
+    id BIGINT UNSIGNED AUTO_INCREMENT PRIMARY KEY,
+    budget_id BIGINT UNSIGNED NOT NULL,
+    producto_id BIGINT UNSIGNED NULL,
+    descripcion VARCHAR(255) NOT NULL,
+    cantidad DECIMAL(12,3) NOT NULL DEFAULT 1,
+    precio_unitario DECIMAL(14,2) NOT NULL DEFAULT 0,
+    iva_porcentaje DECIMAL(5,2) NOT NULL DEFAULT 21.00,
+    irpf_porcentaje DECIMAL(5,2) NULL,
+    subtotal DECIMAL(14,2) NOT NULL DEFAULT 0,
+    created_at TIMESTAMP NULL DEFAULT NULL,
+    updated_at TIMESTAMP NULL DEFAULT NULL,
+    INDEX budget_products_budget_id_index (budget_id),
+    CONSTRAINT budget_products_budget_id_foreign FOREIGN KEY (budget_id) REFERENCES budgets(id)
+        ON UPDATE CASCADE ON DELETE CASCADE,
+    CONSTRAINT budget_products_producto_id_foreign FOREIGN KEY (producto_id) REFERENCES productos(id)
+        ON UPDATE CASCADE ON DELETE SET NULL
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+
 -- Presupuestos
 CREATE TABLE presupuestos (
     id BIGINT UNSIGNED AUTO_INCREMENT PRIMARY KEY,


### PR DESCRIPTION
## Summary
- include budget_products table definition in schema SQL file

## Testing
- `composer install --no-progress` *(fails: curl error 56 while downloading symfony/polyfill-mbstring, response 403)*

------
https://chatgpt.com/codex/tasks/task_e_689a422adafc83219ccf1357605a7426